### PR TITLE
Add `masks` field as array of strings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,62 @@
 # Countries Phone Masks
+
 Phone masks, ISO codes and flags for all countries
 
 ## Inspiration
+
 After the need to add international phone masks into an application, I stumbled upon many libraries but they seemed too outdated or just too complex to just give me the country code, country name, flag and phone mask.
+
 This list contains a hybrid of gists, libraries and wikipedia articles.
 Any issues, kindly, consider creating an issue or a pull request.
 
 ## Installation
-```npm install countries-phone-masks```
+
+To install the package, run the `install` command with your package manager of choice:
+
+```shell
+npm install countries-phone-masks
+```
 
 ## Import
-```js
-const countries = require('countries-phone-masks')
-// or 
-import countries from 'countries-phone-masks'
+
+The package exports an array of objects. You can import the package using CommonJS syntax:
+
+```javascript
+const countries = require("countries-phone-masks");
+```
+
+Or using ES6 modules:
+
+```javascript
+import countries from "countries-phone-masks";
+```
+
+The package also exports a type definition for TypeScript:
+
+```typescript
+import type { Country } from "countries-phone-masks";
 ```
 
 ## Usage
-```js
-console.log(countries.find(({ name }) => name === 'Brazil'))
-// {
-//   name: 'Brazil',
-//   code: '+55',
-//   iso: 'BR',
-//   flag: 'https://cdn.kcak11.com/CountryFlags/countries/br.svg',
-//   mask: [ '(##)####-####', '(##)#####-####' ]
-// }
+
+```javascript
+const countries = require("countries-phone-masks");
+
+const country = countries.find(({ name }) => name === "Brazil");
+
+console.log(country);
 ```
+
+Running the code above will output the following object:
+
+```json
+{
+  "name": "Brazil",
+  "code": "+55",
+  "iso": "BR",
+  "flag": "https://cdn.kcak11.com/CountryFlags/countries/br.svg",
+  "mask": "(##)####-####",
+  "masks": [ "(##)####-####", "(##)#####-####" ]
+}
+```
+

--- a/src/countries.json
+++ b/src/countries.json
@@ -4,189 +4,268 @@
     "code": "+93",
     "iso": "AF",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/af.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Aland Islands",
     "code": "+358",
     "iso": "AX",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ax.svg",
-    "mask": "(###)###-##-##"
+    "mask": "(###)###-##-##",
+    "masks": [
+      "(###)###-##-##"
+    ]
   },
   {
     "name": "Albania",
     "code": "+355",
     "iso": "AL",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/al.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Algeria",
     "code": "+213",
     "iso": "DZ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/dz.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "American Samoa",
     "code": "+1",
     "iso": "AS",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/as.svg",
-    "mask": "(684)###-####"
+    "mask": "(684)###-####",
+    "masks": [
+      "(684)###-####"
+    ]
   },
   {
     "name": "Andorra",
     "code": "+376",
     "iso": "AD",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ad.svg",
-    "mask": "###-###"
+    "mask": "###-###",
+    "masks": [
+      "###-###"
+    ]
   },
   {
     "name": "Angola",
     "code": "+244",
     "iso": "AO",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ao.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Anguilla",
     "code": "+1",
     "iso": "AI",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ai.svg",
-    "mask": "(264)###-####"
+    "mask": "(264)###-####",
+    "masks": [
+      "(264)###-####"
+    ]
   },
   {
     "name": "Antarctica",
     "code": "+672",
     "iso": "AQ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/aq.svg",
-    "mask": "1##-###"
+    "mask": "1##-###",
+    "masks": [
+      "1##-###"
+    ]
   },
   {
     "name": "Antigua and Barbuda",
     "code": "+1",
     "iso": "AG",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ag.svg",
-    "mask": "(268)###-####"
+    "mask": "(268)###-####",
+    "masks": [
+      "(268)###-####"
+    ]
   },
   {
     "name": "Argentina",
     "code": "+54",
     "iso": "AR",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ar.svg",
-    "mask": "(###)###-####"
+    "mask": "(###)###-####",
+    "masks": [
+      "(###)###-####"
+    ]
   },
   {
     "name": "Armenia",
     "code": "+374",
     "iso": "AM",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/am.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Aruba",
     "code": "+297",
     "iso": "AW",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/aw.svg",
-    "mask": "###-####"
+    "mask": "###-####",
+    "masks": [
+      "###-####"
+    ]
   },
   {
     "name": "Ascension Island",
     "code": "+247",
     "iso": "AC",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sh.svg",
-    "mask": "####"
+    "mask": "####",
+    "masks": [
+      "####"
+    ]
   },
   {
     "name": "Australia",
     "code": "+61",
     "iso": "AU",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/au.svg",
-    "mask": "#-####-####"
+    "mask": "#-####-####",
+    "masks": [
+      "#-####-####"
+    ]
   },
   {
     "name": "Austria",
     "code": "+43",
     "iso": "AT",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/at.svg",
-    "mask": "(###)###-####"
+    "mask": "(###)###-####",
+    "masks": [
+      "(###)###-####"
+    ]
   },
   {
     "name": "Azerbaijan",
     "code": "+994",
     "iso": "AZ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/az.svg",
-    "mask": "##-###-##-##"
+    "mask": "##-###-##-##",
+    "masks": [
+      "##-###-##-##"
+    ]
   },
   {
     "name": "Bahamas",
     "code": "+1",
     "iso": "BS",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/bs.svg",
-    "mask": "(242)###-####"
+    "mask": "(242)###-####",
+    "masks": [
+      "(242)###-####"
+    ]
   },
   {
     "name": "Bahrain",
     "code": "+973",
     "iso": "BH",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/bh.svg",
-    "mask": "####-####"
+    "mask": "####-####",
+    "masks": [
+      "####-####"
+    ]
   },
   {
     "name": "Bangladesh",
     "code": "+880",
     "iso": "BD",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/bd.svg",
-    "mask": "1###-######"
+    "mask": "1###-######",
+    "masks": [
+      "1###-######"
+    ]
   },
   {
     "name": "Barbados",
     "code": "+1",
     "iso": "BB",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/bb.svg",
-    "mask": "(246)###-####"
+    "mask": "(246)###-####",
+    "masks": [
+      "(246)###-####"
+    ]
   },
   {
     "name": "Belarus",
     "code": "+375",
     "iso": "BY",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/by.svg",
-    "mask": "(##)###-##-##"
+    "mask": "(##)###-##-##",
+    "masks": [
+      "(##)###-##-##"
+    ]
   },
   {
     "name": "Belgium",
     "code": "+32",
     "iso": "BE",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/be.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Belize",
     "code": "+501",
     "iso": "BZ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/bz.svg",
-    "mask": "###-####"
+    "mask": "###-####",
+    "masks": [
+      "###-####"
+    ]
   },
   {
     "name": "Benin",
     "code": "+229",
     "iso": "BJ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/bj.svg",
-    "mask": "##-##-####"
+    "mask": "##-##-####",
+    "masks": [
+      "##-##-####"
+    ]
   },
   {
     "name": "Bermuda",
     "code": "+1",
     "iso": "BM",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/bm.svg",
-    "mask": "(441)###-####"
+    "mask": "(441)###-####",
+    "masks": [
+      "(441)###-####"
+    ]
   },
   {
     "name": "Bhutan",
     "code": "+975",
     "iso": "BT",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/bt.svg",
-    "mask": [
+    "mask": "17-###-###",
+    "masks": [
       "17-###-###",
       "77-###-###",
       "#-###-###"
@@ -197,14 +276,18 @@
     "code": "+591",
     "iso": "BO",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/bo.svg",
-    "mask": "#-###-####"
+    "mask": "#-###-####",
+    "masks": [
+      "#-###-####"
+    ]
   },
   {
     "name": "Bosnia and Herzegovina",
     "code": "+387",
     "iso": "BA",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ba.svg",
-    "mask": [
+    "mask": "##-####",
+    "masks": [
       "##-####",
       "##-#####"
     ]
@@ -214,14 +297,18 @@
     "code": "+267",
     "iso": "BW",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/bw.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Brazil",
     "code": "+55",
     "iso": "BR",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/br.svg",
-    "mask": [
+    "mask": "(##)####-####",
+    "masks": [
       "(##)####-####",
       "(##)#####-####"
     ]
@@ -231,98 +318,138 @@
     "code": "+246",
     "iso": "IO",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/io.svg",
-    "mask": "###-####"
+    "mask": "###-####",
+    "masks": [
+      "###-####"
+    ]
   },
   {
     "name": "Brunei Darussalam",
     "code": "+673",
     "iso": "BN",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/bn.svg",
-    "mask": "###-####"
+    "mask": "###-####",
+    "masks": [
+      "###-####"
+    ]
   },
   {
     "name": "Bulgaria",
     "code": "+359",
     "iso": "BG",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/bg.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Burkina Faso",
     "code": "+226",
     "iso": "BF",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/bf.svg",
-    "mask": "##-##-####"
+    "mask": "##-##-####",
+    "masks": [
+      "##-##-####"
+    ]
   },
   {
     "name": "Burundi",
     "code": "+257",
     "iso": "BI",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/bi.svg",
-    "mask": "##-##-####"
+    "mask": "##-##-####",
+    "masks": [
+      "##-##-####"
+    ]
   },
   {
     "name": "Cambodia",
     "code": "+855",
     "iso": "KH",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/kh.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Cameroon",
     "code": "+237",
     "iso": "CM",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/cm.svg",
-    "mask": "####-####"
+    "mask": "####-####",
+    "masks": [
+      "####-####"
+    ]
   },
   {
     "name": "Canada",
     "code": "+1",
     "iso": "CA",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ca.svg",
-    "mask": "(###)###-####"
+    "mask": "(###)###-####",
+    "masks": [
+      "(###)###-####"
+    ]
   },
   {
     "name": "Cape Verde",
     "code": "+238",
     "iso": "CV",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/cv.svg",
-    "mask": "(###)##-##"
+    "mask": "(###)##-##",
+    "masks": [
+      "(###)##-##"
+    ]
   },
   {
     "name": "Cayman Islands",
     "code": "+1",
     "iso": "KY",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ky.svg",
-    "mask": "(345)###-####"
+    "mask": "(345)###-####",
+    "masks": [
+      "(345)###-####"
+    ]
   },
   {
     "name": "Central African Republic",
     "code": "+236",
     "iso": "CF",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/cf.svg",
-    "mask": "##-##-####"
+    "mask": "##-##-####",
+    "masks": [
+      "##-##-####"
+    ]
   },
   {
     "name": "Chad",
     "code": "+235",
     "iso": "TD",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/td.svg",
-    "mask": "##-##-##-##"
+    "mask": "##-##-##-##",
+    "masks": [
+      "##-##-##-##"
+    ]
   },
   {
     "name": "Chile",
     "code": "+56",
     "iso": "CL",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/cl.svg",
-    "mask": "#-####-####"
+    "mask": "#-####-####",
+    "masks": [
+      "#-####-####"
+    ]
   },
   {
     "name": "China",
     "code": "+86",
     "iso": "CN",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/cn.svg",
-    "mask": [
+    "mask": "(###)####-###",
+    "masks": [
       "(###)####-###",
       "(###)####-####",
       "##-#####-#####"
@@ -333,112 +460,158 @@
     "code": "+61",
     "iso": "CX",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/cx.svg",
-    "mask": "#-####-####"
+    "mask": "#-####-####",
+    "masks": [
+      "#-####-####"
+    ]
   },
   {
     "name": "Cocos (Keeling) Islands",
     "code": "+61",
     "iso": "CC",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/cc.svg",
-    "mask": "#-####-####"
+    "mask": "#-####-####",
+    "masks": [
+      "#-####-####"
+    ]
   },
   {
     "name": "Colombia",
     "code": "+57",
     "iso": "CO",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/co.svg",
-    "mask": "(###)###-####"
+    "mask": "(###)###-####",
+    "masks": [
+      "(###)###-####"
+    ]
   },
   {
     "name": "Comoros",
     "code": "+269",
     "iso": "KM",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/km.svg",
-    "mask": "##-#####"
+    "mask": "##-#####",
+    "masks": [
+      "##-#####"
+    ]
   },
   {
     "name": "Congo",
     "code": "+242",
     "iso": "CG",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/cg.svg",
-    "mask": "##-#####"
+    "mask": "##-#####",
+    "masks": [
+      "##-#####"
+    ]
   },
   {
     "name": "Cook Islands",
     "code": "+682",
     "iso": "CK",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ck.svg",
-    "mask": "##-###"
+    "mask": "##-###",
+    "masks": [
+      "##-###"
+    ]
   },
   {
     "name": "Costa Rica",
     "code": "+506",
     "iso": "CR",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/cr.svg",
-    "mask": "####-####"
+    "mask": "####-####",
+    "masks": [
+      "####-####"
+    ]
   },
   {
     "name": "Croatia",
     "code": "+385",
     "iso": "HR",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/hr.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Cuba",
     "code": "+53",
     "iso": "CU",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/cu.svg",
-    "mask": "#-###-####"
+    "mask": "#-###-####",
+    "masks": [
+      "#-###-####"
+    ]
   },
   {
     "name": "Cyprus",
     "code": "+357",
     "iso": "CY",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/cy.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Czech Republic",
     "code": "+420",
     "iso": "CZ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/cz.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Democratic Republic of the Congo",
     "code": "+243",
     "iso": "CD",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/cd.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Denmark",
     "code": "+45",
     "iso": "DK",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/dk.svg",
-    "mask": "##-##-##-##"
+    "mask": "##-##-##-##",
+    "masks": [
+      "##-##-##-##"
+    ]
   },
   {
     "name": "Djibouti",
     "code": "+253",
     "iso": "DJ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/dj.svg",
-    "mask": "##-##-##-##"
+    "mask": "##-##-##-##",
+    "masks": [
+      "##-##-##-##"
+    ]
   },
   {
     "name": "Dominica",
     "code": "+1",
     "iso": "DM",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/dm.svg",
-    "mask": "(767)###-####"
+    "mask": "(767)###-####",
+    "masks": [
+      "(767)###-####"
+    ]
   },
   {
     "name": "Dominican Republic",
     "code": "+1",
     "iso": "DO",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/do.svg",
-    "mask": [
+    "mask": "(809)###-####",
+    "masks": [
       "(809)###-####",
       "(829)###-####",
       "(849)###-####"
@@ -449,7 +622,8 @@
     "code": "+593",
     "iso": "EC",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ec.svg",
-    "mask": [
+    "mask": "#-###-####",
+    "masks": [
       "#-###-####",
       "##-###-####"
     ]
@@ -459,35 +633,48 @@
     "code": "+20",
     "iso": "EG",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/eg.svg",
-    "mask": "(###)###-####"
+    "mask": "(###)###-####",
+    "masks": [
+      "(###)###-####"
+    ]
   },
   {
     "name": "El Salvador",
     "code": "+503",
     "iso": "SV",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sv.svg",
-    "mask": "##-##-####"
+    "mask": "##-##-####",
+    "masks": [
+      "##-##-####"
+    ]
   },
   {
     "name": "Equatorial Guinea",
     "code": "+240",
     "iso": "GQ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gq.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Eritrea",
     "code": "+291",
     "iso": "ER",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/er.svg",
-    "mask": "#-###-###"
+    "mask": "#-###-###",
+    "masks": [
+      "#-###-###"
+    ]
   },
   {
     "name": "Estonia",
     "code": "+372",
     "iso": "EE",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ee.svg",
-    "mask": [
+    "mask": "###-####",
+    "masks": [
       "###-####",
       "####-####"
     ]
@@ -497,91 +684,128 @@
     "code": "+268",
     "iso": "SZ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sz.svg",
-    "mask": "##-##-####"
+    "mask": "##-##-####",
+    "masks": [
+      "##-##-####"
+    ]
   },
   {
     "name": "Ethiopia",
     "code": "+251",
     "iso": "ET",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/et.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Falkland Islands (Malvinas)",
     "code": "+500",
     "iso": "FK",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/fk.svg",
-    "mask": "#####"
+    "mask": "#####",
+    "masks": [
+      "#####"
+    ]
   },
   {
     "name": "Faroe Islands",
     "code": "+298",
     "iso": "FO",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/fo.svg",
-    "mask": "###-###"
+    "mask": "###-###",
+    "masks": [
+      "###-###"
+    ]
   },
   {
     "name": "Fiji",
     "code": "+679",
     "iso": "FJ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/fj.svg",
-    "mask": "##-#####"
+    "mask": "##-#####",
+    "masks": [
+      "##-#####"
+    ]
   },
   {
     "name": "Finland",
     "code": "+358",
     "iso": "FI",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/fi.svg",
-    "mask": "(###)###-##-##"
+    "mask": "(###)###-##-##",
+    "masks": [
+      "(###)###-##-##"
+    ]
   },
   {
     "name": "France",
     "code": "+33",
     "iso": "FR",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/fr.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "French Guiana",
     "code": "+594",
     "iso": "GF",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gf.svg",
-    "mask": "#####-####"
+    "mask": "#####-####",
+    "masks": [
+      "#####-####"
+    ]
   },
   {
     "name": "French Polynesia",
     "code": "+689",
     "iso": "PF",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/pf.svg",
-    "mask": "##-##-##"
+    "mask": "##-##-##",
+    "masks": [
+      "##-##-##"
+    ]
   },
   {
     "name": "Gabon",
     "code": "+241",
     "iso": "GA",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ga.svg",
-    "mask": "#-##-##-##"
+    "mask": "#-##-##-##",
+    "masks": [
+      "#-##-##-##"
+    ]
   },
   {
     "name": "Gambia",
     "code": "+220",
     "iso": "GM",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gm.svg",
-    "mask": "(###)##-##"
+    "mask": "(###)##-##",
+    "masks": [
+      "(###)##-##"
+    ]
   },
   {
     "name": "Georgia",
     "code": "+995",
     "iso": "GE",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ge.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Germany",
     "code": "+49",
     "iso": "DE",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/de.svg",
-    "mask": [
+    "mask": "###-###",
+    "masks": [
       "###-###",
       "(###)##-##",
       "(###)##-###",
@@ -595,140 +819,198 @@
     "code": "+233",
     "iso": "GH",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gh.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Gibraltar",
     "code": "+350",
     "iso": "GI",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gi.svg",
-    "mask": "###-#####"
+    "mask": "###-#####",
+    "masks": [
+      "###-#####"
+    ]
   },
   {
     "name": "Greece",
     "code": "+30",
     "iso": "GR",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gr.svg",
-    "mask": "(###)###-####"
+    "mask": "(###)###-####",
+    "masks": [
+      "(###)###-####"
+    ]
   },
   {
     "name": "Greenland",
     "code": "+299",
     "iso": "GL",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gl.svg",
-    "mask": "##-##-##"
+    "mask": "##-##-##",
+    "masks": [
+      "##-##-##"
+    ]
   },
   {
     "name": "Grenada",
     "code": "+1",
     "iso": "GD",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gd.svg",
-    "mask": "(473)###-####"
+    "mask": "(473)###-####",
+    "masks": [
+      "(473)###-####"
+    ]
   },
   {
     "name": "Guadeloupe",
     "code": "+590",
     "iso": "GP",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gp.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Guam",
     "code": "+1",
     "iso": "GU",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gu.svg",
-    "mask": "(671)###-####"
+    "mask": "(671)###-####",
+    "masks": [
+      "(671)###-####"
+    ]
   },
   {
     "name": "Guatemala",
     "code": "+502",
     "iso": "GT",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gt.svg",
-    "mask": "#-###-####"
+    "mask": "#-###-####",
+    "masks": [
+      "#-###-####"
+    ]
   },
   {
     "name": "Guernsey",
     "code": "+44",
     "iso": "GG",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gg.svg",
-    "mask": "(####)######"
+    "mask": "(####)######",
+    "masks": [
+      "(####)######"
+    ]
   },
   {
     "name": "Guinea",
     "code": "+224",
     "iso": "GN",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gn.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Guinea-Bissau",
     "code": "+245",
     "iso": "GW",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gw.svg",
-    "mask": "#-######"
+    "mask": "#-######",
+    "masks": [
+      "#-######"
+    ]
   },
   {
     "name": "Guyana",
     "code": "+592",
     "iso": "GY",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gy.svg",
-    "mask": "###-####"
+    "mask": "###-####",
+    "masks": [
+      "###-####"
+    ]
   },
   {
     "name": "Haiti",
     "code": "+509",
     "iso": "HT",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ht.svg",
-    "mask": "##-##-####"
+    "mask": "##-##-####",
+    "masks": [
+      "##-##-####"
+    ]
   },
   {
     "name": "Holy See (Vatican City State)",
     "code": "+39",
     "iso": "VA",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/va.svg",
-    "mask": "06 698#####"
+    "mask": "06 698#####",
+    "masks": [
+      "06 698#####"
+    ]
   },
   {
     "name": "Honduras",
     "code": "+504",
     "iso": "HN",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/hn.svg",
-    "mask": "####-####"
+    "mask": "####-####",
+    "masks": [
+      "####-####"
+    ]
   },
   {
     "name": "Hong Kong",
     "code": "+852",
     "iso": "HK",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/hk.svg",
-    "mask": "####-####"
+    "mask": "####-####",
+    "masks": [
+      "####-####"
+    ]
   },
   {
     "name": "Hungary",
     "code": "+36",
     "iso": "HU",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/hu.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Iceland",
     "code": "+354",
     "iso": "IS",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/is.svg",
-    "mask": "###-####"
+    "mask": "###-####",
+    "masks": [
+      "###-####"
+    ]
   },
   {
     "name": "India",
     "code": "+91",
     "iso": "IN",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/in.svg",
-    "mask": "(####)###-###"
+    "mask": "(####)###-###",
+    "masks": [
+      "(####)###-###"
+    ]
   },
   {
     "name": "Indonesia",
     "code": "+62",
     "iso": "ID",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/id.svg",
-    "mask": [
+    "mask": "##-###-##",
+    "masks": [
       "##-###-##",
       "##-###-###",
       "##-###-####",
@@ -741,35 +1023,48 @@
     "code": "+98",
     "iso": "IR",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ir.svg",
-    "mask": "(###)###-####"
+    "mask": "(###)###-####",
+    "masks": [
+      "(###)###-####"
+    ]
   },
   {
     "name": "Iraq",
     "code": "+964",
     "iso": "IQ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/iq.svg",
-    "mask": "(###)###-####"
+    "mask": "(###)###-####",
+    "masks": [
+      "(###)###-####"
+    ]
   },
   {
     "name": "Ireland",
     "code": "+353",
     "iso": "IE",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ie.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Isle of Man",
     "code": "+44",
     "iso": "IM",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/im.svg",
-    "mask": "(####)######"
+    "mask": "(####)######",
+    "masks": [
+      "(####)######"
+    ]
   },
   {
     "name": "Israel",
     "code": "+972",
     "iso": "IL",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/il.svg",
-    "mask": [
+    "mask": "#-###-####",
+    "masks": [
       "#-###-####",
       "5#-###-####"
     ]
@@ -779,28 +1074,38 @@
     "code": "+39",
     "iso": "IT",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/it.svg",
-    "mask": "(###)####-###"
+    "mask": "(###)####-###",
+    "masks": [
+      "(###)####-###"
+    ]
   },
   {
     "name": "Ivory Coast / Cote d'Ivoire",
     "code": "+225",
     "iso": "CI",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ci.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Jamaica",
     "code": "+1",
     "iso": "JM",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/jm.svg",
-    "mask": "(876)###-####"
+    "mask": "(876)###-####",
+    "masks": [
+      "(876)###-####"
+    ]
   },
   {
     "name": "Japan",
     "code": "+81",
     "iso": "JP",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/jp.svg",
-    "mask": [
+    "mask": "(###)###-###",
+    "masks": [
       "(###)###-###",
       "##-####-####"
     ]
@@ -810,21 +1115,28 @@
     "code": "+44",
     "iso": "JE",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/je.svg",
-    "mask": "(####)####-######"
+    "mask": "(####)####-######",
+    "masks": [
+      "(####)####-######"
+    ]
   },
   {
     "name": "Jordan",
     "code": "+962",
     "iso": "JO",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/jo.svg",
-    "mask": "#-####-####"
+    "mask": "#-####-####",
+    "masks": [
+      "#-####-####"
+    ]
   },
   {
     "name": "Kazakhstan",
     "code": "+77",
     "iso": "KZ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/kz.svg",
-    "mask": [
+    "mask": "(6##)###-##-##",
+    "masks": [
       "(6##)###-##-##",
       "(7##)###-##-##"
     ]
@@ -834,21 +1146,28 @@
     "code": "+254",
     "iso": "KE",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ke.svg",
-    "mask": "###-######"
+    "mask": "###-######",
+    "masks": [
+      "###-######"
+    ]
   },
   {
     "name": "Kiribati",
     "code": "+686",
     "iso": "KI",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ki.svg",
-    "mask": "##-###"
+    "mask": "##-###",
+    "masks": [
+      "##-###"
+    ]
   },
   {
     "name": "Korea, Democratic People's Republic of Korea",
     "code": "+850",
     "iso": "KP",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/kp.svg",
-    "mask": [
+    "mask": "###-###",
+    "masks": [
       "###-###",
       "####-####",
       "##-###-###",
@@ -862,14 +1181,18 @@
     "code": "+82",
     "iso": "KR",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/kr.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Kosovo",
     "code": "+383",
     "iso": "XK",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/xk.svg",
-    "mask": [
+    "mask": "##-###-###",
+    "masks": [
       "##-###-###",
       "###-###-###"
     ]
@@ -879,21 +1202,28 @@
     "code": "+965",
     "iso": "KW",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/kw.svg",
-    "mask": "####-####"
+    "mask": "####-####",
+    "masks": [
+      "####-####"
+    ]
   },
   {
     "name": "Kyrgyzstan",
     "code": "+996",
     "iso": "KG",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/kg.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Laos",
     "code": "+856",
     "iso": "LA",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/la.svg",
-    "mask": [
+    "mask": "##-###-###",
+    "masks": [
       "##-###-###",
       "(20##)###-###"
     ]
@@ -903,14 +1233,18 @@
     "code": "+371",
     "iso": "LV",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/lv.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Lebanon",
     "code": "+961",
     "iso": "LB",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/lb.svg",
-    "mask": [
+    "mask": "#-###-###",
+    "masks": [
       "#-###-###",
       "##-###-###"
     ]
@@ -920,21 +1254,28 @@
     "code": "+266",
     "iso": "LS",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ls.svg",
-    "mask": "#-###-####"
+    "mask": "#-###-####",
+    "masks": [
+      "#-###-####"
+    ]
   },
   {
     "name": "Liberia",
     "code": "+231",
     "iso": "LR",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/lr.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Libya",
     "code": "+218",
     "iso": "LY",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ly.svg",
-    "mask": [
+    "mask": "##-###-###",
+    "masks": [
       "##-###-###",
       "21-###-####"
     ]
@@ -944,42 +1285,58 @@
     "code": "+423",
     "iso": "LI",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/li.svg",
-    "mask": "(###)###-####"
+    "mask": "(###)###-####",
+    "masks": [
+      "(###)###-####"
+    ]
   },
   {
     "name": "Lithuania",
     "code": "+370",
     "iso": "LT",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/lt.svg",
-    "mask": "(###)##-###"
+    "mask": "(###)##-###",
+    "masks": [
+      "(###)##-###"
+    ]
   },
   {
     "name": "Luxembourg",
     "code": "+352",
     "iso": "LU",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/lu.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Macau",
     "code": "+853",
     "iso": "MO",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mo.svg",
-    "mask": "####-####"
+    "mask": "####-####",
+    "masks": [
+      "####-####"
+    ]
   },
   {
     "name": "Madagascar",
     "code": "+261",
     "iso": "MG",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mg.svg",
-    "mask": "##-##-#####"
+    "mask": "##-##-#####",
+    "masks": [
+      "##-##-#####"
+    ]
   },
   {
     "name": "Malawi",
     "code": "+265",
     "iso": "MW",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mw.svg",
-    "mask": [
+    "mask": "1-###-###",
+    "masks": [
       "1-###-###",
       "#-####-####"
     ]
@@ -989,7 +1346,8 @@
     "code": "+60",
     "iso": "MY",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/my.svg",
-    "mask": [
+    "mask": "#-###-###",
+    "masks": [
       "#-###-###",
       "##-###-###",
       "(###)###-###",
@@ -1001,63 +1359,88 @@
     "code": "+960",
     "iso": "MV",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mv.svg",
-    "mask": "###-####"
+    "mask": "###-####",
+    "masks": [
+      "###-####"
+    ]
   },
   {
     "name": "Mali",
     "code": "+223",
     "iso": "ML",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ml.svg",
-    "mask": "##-##-####"
+    "mask": "##-##-####",
+    "masks": [
+      "##-##-####"
+    ]
   },
   {
     "name": "Malta",
     "code": "+356",
     "iso": "MT",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mt.svg",
-    "mask": "####-####"
+    "mask": "####-####",
+    "masks": [
+      "####-####"
+    ]
   },
   {
     "name": "Marshall Islands",
     "code": "+692",
     "iso": "MH",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mh.svg",
-    "mask": "###-####"
+    "mask": "###-####",
+    "masks": [
+      "###-####"
+    ]
   },
   {
     "name": "Martinique",
     "code": "+596",
     "iso": "MQ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mq.svg",
-    "mask": "(###)##-##-##"
+    "mask": "(###)##-##-##",
+    "masks": [
+      "(###)##-##-##"
+    ]
   },
   {
     "name": "Mauritania",
     "code": "+222",
     "iso": "MR",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mr.svg",
-    "mask": "##-##-####"
+    "mask": "##-##-####",
+    "masks": [
+      "##-##-####"
+    ]
   },
   {
     "name": "Mauritius",
     "code": "+230",
     "iso": "MU",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mu.svg",
-    "mask": "###-####"
+    "mask": "###-####",
+    "masks": [
+      "###-####"
+    ]
   },
   {
     "name": "Mayotte",
     "code": "+262",
     "iso": "YT",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/yt.svg",
-    "mask": "#####-####"
+    "mask": "#####-####",
+    "masks": [
+      "#####-####"
+    ]
   },
   {
     "name": "Mexico",
     "code": "+52",
     "iso": "MX",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mx.svg",
-    "mask": [
+    "mask": "##-##-####",
+    "masks": [
       "##-##-####",
       "(###)###-####"
     ]
@@ -1067,21 +1450,28 @@
     "code": "+691",
     "iso": "FM",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/fm.svg",
-    "mask": "###-####"
+    "mask": "###-####",
+    "masks": [
+      "###-####"
+    ]
   },
   {
     "name": "Moldova",
     "code": "+373",
     "iso": "MD",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/md.svg",
-    "mask": "####-####"
+    "mask": "####-####",
+    "masks": [
+      "####-####"
+    ]
   },
   {
     "name": "Monaco",
     "code": "+377",
     "iso": "MC",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mc.svg",
-    "mask": [
+    "mask": "##-###-###",
+    "masks": [
       "##-###-###",
       "(###)###-###"
     ]
@@ -1091,42 +1481,58 @@
     "code": "+976",
     "iso": "MN",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mn.svg",
-    "mask": "##-##-####"
+    "mask": "##-##-####",
+    "masks": [
+      "##-##-####"
+    ]
   },
   {
     "name": "Montenegro",
     "code": "+382",
     "iso": "ME",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/me.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Montserrat",
     "code": "+1",
     "iso": "MS",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ms.svg",
-    "mask": "(664)###-####"
+    "mask": "(664)###-####",
+    "masks": [
+      "(664)###-####"
+    ]
   },
   {
     "name": "Morocco",
     "code": "+212",
     "iso": "MA",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ma.svg",
-    "mask": "##-####-###"
+    "mask": "##-####-###",
+    "masks": [
+      "##-####-###"
+    ]
   },
   {
     "name": "Mozambique",
     "code": "+258",
     "iso": "MZ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mz.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Myanmar",
     "code": "+95",
     "iso": "MM",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mm.svg",
-    "mask": [
+    "mask": "###-###",
+    "masks": [
       "###-###",
       "#-###-###",
       "##-###-###"
@@ -1137,42 +1543,58 @@
     "code": "+264",
     "iso": "NA",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/na.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Nauru",
     "code": "+674",
     "iso": "NR",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/nr.svg",
-    "mask": "###-####"
+    "mask": "###-####",
+    "masks": [
+      "###-####"
+    ]
   },
   {
     "name": "Nepal",
     "code": "+977",
     "iso": "NP",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/np.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Netherlands",
     "code": "+31",
     "iso": "NL",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/nl.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "New Caledonia",
     "code": "+687",
     "iso": "NC",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/nc.svg",
-    "mask": "##-####"
+    "mask": "##-####",
+    "masks": [
+      "##-####"
+    ]
   },
   {
     "name": "New Zealand",
     "code": "+64",
     "iso": "NZ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/nz.svg",
-    "mask": [
+    "mask": "#-###-###",
+    "masks": [
       "#-###-###",
       "(###)###-###",
       "(###)###-####"
@@ -1183,21 +1605,28 @@
     "code": "+505",
     "iso": "NI",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ni.svg",
-    "mask": "####-####"
+    "mask": "####-####",
+    "masks": [
+      "####-####"
+    ]
   },
   {
     "name": "Niger",
     "code": "+227",
     "iso": "NE",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ne.svg",
-    "mask": "##-##-####"
+    "mask": "##-##-####",
+    "masks": [
+      "##-##-####"
+    ]
   },
   {
     "name": "Nigeria",
     "code": "+234",
     "iso": "NG",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ng.svg",
-    "mask": [
+    "mask": "##-###-##",
+    "masks": [
       "##-###-##",
       "##-###-###",
       "(###)###-####"
@@ -1208,126 +1637,178 @@
     "code": "+683",
     "iso": "NU",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/nu.svg",
-    "mask": "####"
+    "mask": "####",
+    "masks": [
+      "####"
+    ]
   },
   {
     "name": "Norfolk Island",
     "code": "+672",
     "iso": "NF",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/nf.svg",
-    "mask": "3##-###"
+    "mask": "3##-###",
+    "masks": [
+      "3##-###"
+    ]
   },
   {
     "name": "North Macedonia",
     "code": "+389",
     "iso": "MK",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mk.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Northern Mariana Islands",
     "code": "+1",
     "iso": "MP",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mp.svg",
-    "mask": "(670)###-####"
+    "mask": "(670)###-####",
+    "masks": [
+      "(670)###-####"
+    ]
   },
   {
     "name": "Norway",
     "code": "+47",
     "iso": "NO",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/no.svg",
-    "mask": "(###)##-###"
+    "mask": "(###)##-###",
+    "masks": [
+      "(###)##-###"
+    ]
   },
   {
     "name": "Oman",
     "code": "+968",
     "iso": "OM",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/om.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Pakistan",
     "code": "+92",
     "iso": "PK",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/pk.svg",
-    "mask": "(###)###-####"
+    "mask": "(###)###-####",
+    "masks": [
+      "(###)###-####"
+    ]
   },
   {
     "name": "Palau",
     "code": "+680",
     "iso": "PW",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/pw.svg",
-    "mask": "###-####"
+    "mask": "###-####",
+    "masks": [
+      "###-####"
+    ]
   },
   {
     "name": "Palestine",
     "code": "+970",
     "iso": "PS",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ps.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Panama",
     "code": "+507",
     "iso": "PA",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/pa.svg",
-    "mask": "###-####"
+    "mask": "###-####",
+    "masks": [
+      "###-####"
+    ]
   },
   {
     "name": "Papua New Guinea",
     "code": "+675",
     "iso": "PG",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/pg.svg",
-    "mask": "(###)##-###"
+    "mask": "(###)##-###",
+    "masks": [
+      "(###)##-###"
+    ]
   },
   {
     "name": "Paraguay",
     "code": "+595",
     "iso": "PY",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/py.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Peru",
     "code": "+51",
     "iso": "PE",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/pe.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Philippines",
     "code": "+63",
     "iso": "PH",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ph.svg",
-    "mask": "(###)###-####"
+    "mask": "(###)###-####",
+    "masks": [
+      "(###)###-####"
+    ]
   },
   {
     "name": "Pitcairn",
     "code": "+870",
     "iso": "PN",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/pn.svg",
-    "mask": "###-###-###"
+    "mask": "###-###-###",
+    "masks": [
+      "###-###-###"
+    ]
   },
   {
     "name": "Poland",
     "code": "+48",
     "iso": "PL",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/pl.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Portugal",
     "code": "+351",
     "iso": "PT",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/pt.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Puerto Rico",
     "code": "+1",
     "iso": "PR",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/pr.svg",
-    "mask": [
+    "mask": "(787) ### ####",
+    "masks": [
       "(787) ### ####",
       "(939) ### ####"
     ]
@@ -1337,112 +1818,158 @@
     "code": "+974",
     "iso": "QA",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/qa.svg",
-    "mask": "####-####"
+    "mask": "####-####",
+    "masks": [
+      "####-####"
+    ]
   },
   {
     "name": "Reunion",
     "code": "+262",
     "iso": "RE",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/re.svg",
-    "mask": "#####-####"
+    "mask": "#####-####",
+    "masks": [
+      "#####-####"
+    ]
   },
   {
     "name": "Romania",
     "code": "+40",
     "iso": "RO",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ro.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Russia",
     "code": "+7",
     "iso": "RU",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ru.svg",
-    "mask": "(###)###-##-##"
+    "mask": "(###)###-##-##",
+    "masks": [
+      "(###)###-##-##"
+    ]
   },
   {
     "name": "Rwanda",
     "code": "+250",
     "iso": "RW",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/rw.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Saint Barthelemy",
     "code": "+590",
     "iso": "BL",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/bl.svg",
-    "mask": "###-##-##-##"
+    "mask": "###-##-##-##",
+    "masks": [
+      "###-##-##-##"
+    ]
   },
   {
     "name": "Saint Helena, Ascension and Tristan Da Cunha",
     "code": "+290",
     "iso": "SH",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sh.svg",
-    "mask": "####"
+    "mask": "####",
+    "masks": [
+      "####"
+    ]
   },
   {
     "name": "Saint Kitts and Nevis",
     "code": "+1",
     "iso": "KN",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/kn.svg",
-    "mask": "(869)###-####"
+    "mask": "(869)###-####",
+    "masks": [
+      "(869)###-####"
+    ]
   },
   {
     "name": "Saint Lucia",
     "code": "+1",
     "iso": "LC",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/lc.svg",
-    "mask": "(758)###-####"
+    "mask": "(758)###-####",
+    "masks": [
+      "(758)###-####"
+    ]
   },
   {
     "name": "Saint Martin",
     "code": "+590",
     "iso": "MF",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/mf.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Saint Pierre and Miquelon",
     "code": "+508",
     "iso": "PM",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/pm.svg",
-    "mask": "##-####"
+    "mask": "##-####",
+    "masks": [
+      "##-####"
+    ]
   },
   {
     "name": "Saint Vincent and the Grenadines",
     "code": "+1",
     "iso": "VC",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/vc.svg",
-    "mask": "(784)###-####"
+    "mask": "(784)###-####",
+    "masks": [
+      "(784)###-####"
+    ]
   },
   {
     "name": "Samoa",
     "code": "+685",
     "iso": "WS",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ws.svg",
-    "mask": "##-####"
+    "mask": "##-####",
+    "masks": [
+      "##-####"
+    ]
   },
   {
     "name": "San Marino",
     "code": "+378",
     "iso": "SM",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sm.svg",
-    "mask": "####-######"
+    "mask": "####-######",
+    "masks": [
+      "####-######"
+    ]
   },
   {
     "name": "Sao Tome and Principe",
     "code": "+239",
     "iso": "ST",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/st.svg",
-    "mask": "##-#####"
+    "mask": "##-#####",
+    "masks": [
+      "##-#####"
+    ]
   },
   {
     "name": "Saudi Arabia",
     "code": "+966",
     "iso": "SA",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sa.svg",
-    "mask": [
+    "mask": "#-###-####",
+    "masks": [
       "#-###-####",
       "5#-####-####"
     ]
@@ -1452,63 +1979,88 @@
     "code": "+221",
     "iso": "SN",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sn.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Serbia",
     "code": "+381",
     "iso": "RS",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/rs.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Seychelles",
     "code": "+248",
     "iso": "SC",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sc.svg",
-    "mask": "#-###-###"
+    "mask": "#-###-###",
+    "masks": [
+      "#-###-###"
+    ]
   },
   {
     "name": "Sierra Leone",
     "code": "+232",
     "iso": "SL",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sl.svg",
-    "mask": "##-######"
+    "mask": "##-######",
+    "masks": [
+      "##-######"
+    ]
   },
   {
     "name": "Singapore",
     "code": "+65",
     "iso": "SG",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sg.svg",
-    "mask": "####-####"
+    "mask": "####-####",
+    "masks": [
+      "####-####"
+    ]
   },
   {
     "name": "Sint Maarten",
     "code": "+1",
     "iso": "SX",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sx.svg",
-    "mask": "(721)###-####"
+    "mask": "(721)###-####",
+    "masks": [
+      "(721)###-####"
+    ]
   },
   {
     "name": "Slovakia",
     "code": "+421",
     "iso": "SK",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sk.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Slovenia",
     "code": "+386",
     "iso": "SI",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/si.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Solomon Islands",
     "code": "+677",
     "iso": "SB",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sb.svg",
-    "mask": [
+    "mask": "#####",
+    "masks": [
       "#####",
       "###-####"
     ]
@@ -1518,7 +2070,8 @@
     "code": "+252",
     "iso": "SO",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/so.svg",
-    "mask": [
+    "mask": "#-###-###",
+    "masks": [
       "#-###-###",
       "##-###-###"
     ]
@@ -1528,49 +2081,68 @@
     "code": "+27",
     "iso": "ZA",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/za.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "South Georgia and the South Sandwich Islands",
     "code": "+500",
     "iso": "GS",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gs.svg",
-    "mask": "#####"
+    "mask": "#####",
+    "masks": [
+      "#####"
+    ]
   },
   {
     "name": "South Sudan",
     "code": "+211",
     "iso": "SS",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ss.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Spain",
     "code": "+34",
     "iso": "ES",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/es.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Sri Lanka",
     "code": "+94",
     "iso": "LK",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/lk.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Sudan",
     "code": "+249",
     "iso": "SD",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sd.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Suriname",
     "code": "+597",
     "iso": "SR",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sr.svg",
-    "mask": [
+    "mask": "###-###",
+    "masks": [
       "###-###",
       "###-####"
     ]
@@ -1580,35 +2152,48 @@
     "code": "+47",
     "iso": "SJ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sj.svg",
-    "mask": "(###)##-###"
+    "mask": "(###)##-###",
+    "masks": [
+      "(###)##-###"
+    ]
   },
   {
     "name": "Sweden",
     "code": "+46",
     "iso": "SE",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/se.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Switzerland",
     "code": "+41",
     "iso": "CH",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ch.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Syrian Arab Republic",
     "code": "+963",
     "iso": "SY",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/sy.svg",
-    "mask": "##-####-###"
+    "mask": "##-####-###",
+    "masks": [
+      "##-####-###"
+    ]
   },
   {
     "name": "Taiwan",
     "code": "+886",
     "iso": "TW",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/tw.svg",
-    "mask": [
+    "mask": "####-####",
+    "masks": [
       "####-####",
       "#-####-####"
     ]
@@ -1618,21 +2203,28 @@
     "code": "+992",
     "iso": "TJ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/tj.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Tanzania, United Republic of Tanzania",
     "code": "+255",
     "iso": "TZ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/tz.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Thailand",
     "code": "+66",
     "iso": "TH",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/th.svg",
-    "mask": [
+    "mask": "##-###-###",
+    "masks": [
       "##-###-###",
       "##-###-####"
     ]
@@ -1642,7 +2234,8 @@
     "code": "+670",
     "iso": "TL",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/tl.svg",
-    "mask": [
+    "mask": "###-####",
+    "masks": [
       "###-####",
       "77#-#####",
       "78#-#####"
@@ -1653,63 +2246,88 @@
     "code": "+228",
     "iso": "TG",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/tg.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Tokelau",
     "code": "+690",
     "iso": "TK",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/tk.svg",
-    "mask": "####"
+    "mask": "####",
+    "masks": [
+      "####"
+    ]
   },
   {
     "name": "Tonga",
     "code": "+676",
     "iso": "TO",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/to.svg",
-    "mask": "#####"
+    "mask": "#####",
+    "masks": [
+      "#####"
+    ]
   },
   {
     "name": "Trinidad and Tobago",
     "code": "+1",
     "iso": "TT",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/tt.svg",
-    "mask": "(868)###-####"
+    "mask": "(868)###-####",
+    "masks": [
+      "(868)###-####"
+    ]
   },
   {
     "name": "Tunisia",
     "code": "+216",
     "iso": "TN",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/tn.svg",
-    "mask": "##-###-###"
+    "mask": "##-###-###",
+    "masks": [
+      "##-###-###"
+    ]
   },
   {
     "name": "Turkey",
     "code": "+90",
     "iso": "TR",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/tr.svg",
-    "mask": "(###)###-####"
+    "mask": "(###)###-####",
+    "masks": [
+      "(###)###-####"
+    ]
   },
   {
     "name": "Turkmenistan",
     "code": "+993",
     "iso": "TM",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/tm.svg",
-    "mask": "#-###-####"
+    "mask": "#-###-####",
+    "masks": [
+      "#-###-####"
+    ]
   },
   {
     "name": "Turks and Caicos Islands",
     "code": "+1",
     "iso": "TC",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/tc.svg",
-    "mask": "(249)###-###"
+    "mask": "(249)###-###",
+    "masks": [
+      "(249)###-###"
+    ]
   },
   {
     "name": "Tuvalu",
     "code": "+688",
     "iso": "TV",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/tv.svg",
-    "mask": [
+    "mask": "2####",
+    "masks": [
       "2####",
       "90####"
     ]
@@ -1719,21 +2337,28 @@
     "code": "+256",
     "iso": "UG",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ug.svg",
-    "mask": "(###)###-###"
+    "mask": "(###)###-###",
+    "masks": [
+      "(###)###-###"
+    ]
   },
   {
     "name": "Ukraine",
     "code": "+380",
     "iso": "UA",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ua.svg",
-    "mask": "(##)###-##-##"
+    "mask": "(##)###-##-##",
+    "masks": [
+      "(##)###-##-##"
+    ]
   },
   {
     "name": "United Arab Emirates",
     "code": "+971",
     "iso": "AE",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ae.svg",
-    "mask": [
+    "mask": "#-###-####",
+    "masks": [
       "#-###-####",
       "5#-###-####"
     ]
@@ -1743,35 +2368,48 @@
     "code": "+44",
     "iso": "GB",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/gb.svg",
-    "mask": "##-####-####"
+    "mask": "##-####-####",
+    "masks": [
+      "##-####-####"
+    ]
   },
   {
     "name": "United States",
     "code": "+1",
     "iso": "US",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/us.svg",
-    "mask": "(###)###-####"
+    "mask": "(###)###-####",
+    "masks": [
+      "(###)###-####"
+    ]
   },
   {
     "name": "Uruguay",
     "code": "+598",
     "iso": "UY",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/uy.svg",
-    "mask": "#-###-##-##"
+    "mask": "#-###-##-##",
+    "masks": [
+      "#-###-##-##"
+    ]
   },
   {
     "name": "Uzbekistan",
     "code": "+998",
     "iso": "UZ",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/uz.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Vanuatu",
     "code": "+678",
     "iso": "VU",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/vu.svg",
-    "mask": [
+    "mask": "#####",
+    "masks": [
       "#####",
       "##-#####"
     ]
@@ -1781,14 +2419,18 @@
     "code": "+58",
     "iso": "VE",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ve.svg",
-    "mask": "(###)###-####"
+    "mask": "(###)###-####",
+    "masks": [
+      "(###)###-####"
+    ]
   },
   {
     "name": "Vietnam",
     "code": "+84",
     "iso": "VN",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/vn.svg",
-    "mask": [
+    "mask": "##-####-###",
+    "masks": [
       "##-####-###",
       "(###)####-###"
     ]
@@ -1798,28 +2440,38 @@
     "code": "+1",
     "iso": "VG",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/vg.svg",
-    "mask": "(284)###-####"
+    "mask": "(284)###-####",
+    "masks": [
+      "(284)###-####"
+    ]
   },
   {
     "name": "Virgin Islands, U.S.",
     "code": "+1",
     "iso": "VI",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/vi.svg",
-    "mask": "(340)###-####"
+    "mask": "(340)###-####",
+    "masks": [
+      "(340)###-####"
+    ]
   },
   {
     "name": "Wallis and Futuna",
     "code": "+681",
     "iso": "WF",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/wf.svg",
-    "mask": "##-####"
+    "mask": "##-####",
+    "masks": [
+      "##-####"
+    ]
   },
   {
     "name": "Yemen",
     "code": "+967",
     "iso": "YE",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/ye.svg",
-    "mask": [
+    "mask": "#-###-###",
+    "masks": [
       "#-###-###",
       "##-###-###",
       "###-###-###"
@@ -1830,13 +2482,19 @@
     "code": "+260",
     "iso": "ZM",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/zm.svg",
-    "mask": "##-###-####"
+    "mask": "##-###-####",
+    "masks": [
+      "##-###-####"
+    ]
   },
   {
     "name": "Zimbabwe",
     "code": "+263",
     "iso": "ZW",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/zw.svg",
-    "mask": "#-######"
+    "mask": "#-######",
+    "masks": [
+      "#-######"
+    ]
   }
 ]

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,9 +1,45 @@
-interface Country {
+declare interface Country {
+  /** 
+   * The name of the country. 
+   * 
+   * @example "Brazil" 
+   */
   name: string;
+
+  /** 
+   * The Internation call prefix [(IDD code)](https://en.wikipedia.org/wiki/International_direct_dialing#International_call_prefix) of the country. 
+   * 
+   * @example "+55" 
+   */
   code: string;
+
+  /** 
+   * The ISO [3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code of the country.
+   * 
+   * @example "BR" 
+   */
   iso: string;
+
+  /** 
+   * A URL to a SVG file of the country's flag.
+   * 
+   * @example "https://cdn.kcak11.com/CountryFlags/countries/br.svg"
+   */
   flag: string;
+
+  /**
+   * Default mask for the country's phone numbers.
+   * 
+   * @example "(##)####-####"
+   */
   mask: string;
+
+  /**
+   * An array of masks for the country's phone numbers.
+   * 
+   * @example ["(##)####-####", "(##)#####-####"]
+   */
+  masks: string[];
 }
 
 declare const countries: Country[];


### PR DESCRIPTION
I noticed that the `mask` field's returned value from objects varied between a single string and an array of strings. Since the type definitions declares the field as `string` only, I added the `masks` field to return an array of strings and changed the objects that had the `mask` field return an array to return the first string in the array.

changes: 
- adds `masks` field to objects;
- now, the `mask` field returns a string only;
- update type declarations with JSDoc;
- update `README.md`;

#

I created a temporary file in the root of the project to execute the script below to change JSON file: 

```typescript
import Bun from "bun";

import countries from "./src/countries.json"; 

const updatedCountries = countries.map((country) => {
  const masks = Array.isArray(country.mask) 
    ? country.mask 
    : [country.mask];

  return {
    ...country,
    masks,
    mask: masks[0],
  };
});

await Bun.write("./src/countries.json", JSON.stringify(updatedCountries));
```

###### node `22.9.0`, bun `1.1.31`