### PR TITLE
Update masks for JP and PL

### DIFF
--- a/src/countries.json
+++ b/src/countries.json
@@ -800,8 +800,9 @@
     "iso": "JP",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/jp.svg",
     "mask": [
-      "(###)###-###",
-      "##-####-####"
+      "#-####-####",
+      "##-####-####",
+      "###-####-####"
     ]
   },
   {
@@ -1313,7 +1314,10 @@
     "code": "+48",
     "iso": "PL",
     "flag": "https://cdn.kcak11.com/CountryFlags/countries/pl.svg",
-    "mask": "(###)###-###"
+    "mask": [
+      "###-###-###",
+      "##-###-##-##"
+    ]
   },
   {
     "name": "Portugal",


### PR DESCRIPTION
This updates masks for Japan and Poland to use most common format for phone numbers.
